### PR TITLE
Fixes issue with undefined constructor

### DIFF
--- a/sdkgen/nodejs-request/lib/index.js
+++ b/sdkgen/nodejs-request/lib/index.js
@@ -39,7 +39,7 @@ async function generate (collection, options, callback) {
   snippet += getClassDoc(collection, options.variableList);
 
   // class declaration
-  snippet += 'function SDK(config) {\n\n';
+  snippet += 'function SDK(config = {}) {\n\n';
   snippet += options.ES6_enabled ? 'const ' : 'var ';
   snippet += 'self = this;\n\n';
   // Performing first layer individually to avoid adding additional layer to result


### PR DESCRIPTION
Since there is no default value in the generated sdk constructor it gives an err when config parameter is not provied. This pr sets default value ({}) to the config parameter.