### PR TITLE
fixes err with empty variable list

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,7 +125,7 @@ async function generate (collection, options, callback) {
             value: variables[variableKey]
           });
         });
-        variableList = new sdk.VariableList(null, variableList);
+        variableList = variableList.length ? new sdk.VariableList(null, variableList) : undefined;
       }
       return {variables: variableList, collection: collectionInstance};
     },


### PR DESCRIPTION
even when variables were not provided additional methods were generated due to default value of variables object.

Fixed by adding check for length of variable list generated in resolvesources method so that undefined can be passed